### PR TITLE
call environment.retain in lookup case

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,8 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
                 variables: operation.variables,
             };
             if (props.lookup && environment.check(operation.root)) {
+                environment.retain(operation.root);
+
                 // data is available in the store, render without making any requests
                 const snapshot = environment.lookup(operation.fragment);
                 return {


### PR DESCRIPTION
This fixes the issue Evaldas is having in favorites. Not sure whether it breaks other functionality.